### PR TITLE
Add test for log.data

### DIFF
--- a/puter/aws.py
+++ b/puter/aws.py
@@ -4,7 +4,7 @@ import time
 import dateutil.parser
 from botocore.exceptions import ClientError
 
-import log
+from . import log
 
 
 def authorize_security_group_ingress(group_id, ec2):

--- a/puter/log.py
+++ b/puter/log.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 import click
 
-import puter
+from . import puter
 
 
 def text(data):
@@ -38,7 +38,7 @@ def commit(data, stack):
         "meta": {"stack": f"{stack}", "datetime": timestamp},
     }
     log_path = puter.data_dir() / "log.txt"
-    log_path.touch(mode=0o600)
+    # log_path.touch(mode=0o600)
     with open(log_path, "a") as file:
         log_json = json.dumps(log_dict)
         file.write(f"{log_json}\n")

--- a/puter/puter.py
+++ b/puter/puter.py
@@ -10,8 +10,7 @@ import boto3
 import click
 import dateutil.parser
 
-import aws
-import log
+from . import aws, log
 
 
 @click.command(context_settings=dict(max_content_width=120))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+import os
+
+TEST_DATA_DIR = "test_data_dir"
+
+os.environ["XDG_DATA_HOME"] = TEST_DATA_DIR

--- a/tests/test_puter_log.py
+++ b/tests/test_puter_log.py
@@ -1,6 +1,12 @@
+import json
+from pathlib import Path
+from unittest.mock import mock_open
+
 import pytest
 
 import puter.log as log
+
+from .conftest import TEST_DATA_DIR
 
 
 def test_text(mocker):
@@ -8,14 +14,24 @@ def test_text(mocker):
     log.text("text")
     mock_echo.assert_called_with("text")
 
-def test_data_dir(mocker):
-    mock_echo = mocker.patch("click.echo")
-    log.text("text")
-    mock_echo.assert_called_with("text")
 
-def test_commit(mocker):
-    mock_isoformat = mocker.patch("datetime.now.isoformat")
-    mock_data_dir = mocker.patch("puter.data_dir")
-    mock_data_dir = mocker.patch("puter.data_dir")
-    log.text("text")
-    mock_click.assert_called_with("text")
+def test_data(mocker):
+
+    # Had to patch datetime in this way because python objected to patching
+    # "now" directly.
+    mock_dt = mocker.patch("puter.log.datetime")
+    mock_dt.now.return_value = mocker.MagicMock(isoformat=lambda: "fake time")
+
+    m = mock_open()  # https://docs.python.org/3.7/library/unittest.mock.html#mock-open
+    mocker.patch("puter.log.open", m)
+
+    to_log = {"foo": "bar"}
+    log.data(to_log)
+
+    m.assert_called_once_with(Path(TEST_DATA_DIR) / "puter" / "log.txt", "a")
+
+    written_file_contents = m().write.mock_calls[0][1][0]
+    written_json = json.loads(written_file_contents)
+
+    assert all(k in written_json for k in to_log.keys())
+    assert all(k in written_json["meta"] for k in ["stack", "datetime"])


### PR DESCRIPTION
Why:

* There was an attempt to test `log.commit` that seemed to be hung up by
  mocking/patching woes.
* `log.commit` is only used privately within `log`, so I opted to test
  `log.data`, which is used extensively in the project and therefore
  seemed like a better interface to test.

This change addresses the need by:

* Testing `log.data` in a basic way that ensures the proper file was
  opened, parsable json was written, and the json has the proper keys